### PR TITLE
sans-serif font updated

### DIFF
--- a/dreamy/style.css
+++ b/dreamy/style.css
@@ -10,7 +10,7 @@ Author URI: http://www.ginger-ninja.net/
 
 body {
 	background:url(images/bg-body.png) repeat-x top center #E8F7F9;
-	font-family:"Trebuchet MS" Arial, Helvetica, sans-serif;
+	font-family:Arial, Helvetica, sans-serif;
 	font-size:62.5%; /* Sets default font size to 10px */
 	color:#222222;
 	}


### PR DESCRIPTION
It is advisable to use sans-serif fonts for longer texts on screens. This significantly minimizes reading fatigue and the font often appears more modern and cleaner.